### PR TITLE
Allow specifying overrides for resource requests or limits alone

### DIFF
--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -86,8 +86,8 @@ class Node(object):
             for k, v in alias_dict.items():
                 self._aliases.append(_workflow_model.Alias(var=k, alias=v))
         if "requests" in kwargs or "limits" in kwargs:
-            requests = _convert_resource_overrides(kwargs["requests"], "requests")
-            limits = _convert_resource_overrides(kwargs["limits"], "limits")
+            requests = _convert_resource_overrides(kwargs.get("requests"), "requests")
+            limits = _convert_resource_overrides(kwargs.get("limits"), "limits")
             self._resources = _resources_model(requests=requests, limits=limits)
         return self
 

--- a/tests/flytekit/unit/core/test_node_creation.py
+++ b/tests/flytekit/unit/core/test_node_creation.py
@@ -166,7 +166,7 @@ def test_runs_before():
     my_wf(a=5, b="hello")
 
 
-def test_resource_overrides():
+def test_resource_request_override():
     @task
     def t1(a: str) -> str:
         return f"*~*~*~{a}*~*~*~"
@@ -174,11 +174,70 @@ def test_resource_overrides():
     @workflow
     def my_wf(a: typing.List[str]) -> typing.List[str]:
         mappy = map_task(t1)
-        map_node = create_node(mappy, a=a).with_overrides(
-            requests=Resources(cpu="1", mem="100", ephemeral_storage="500Mi"),
-            limits=Resources(cpu="2", mem="200", ephemeral_storage="1Gi"),
+        map_node = mappy(a=a).with_overrides(requests=Resources(cpu="1", mem="100", ephemeral_storage="500Mi"))
+        return map_node
+
+    serialization_settings = context_manager.SerializationSettings(
+        project="test_proj",
+        domain="test_domain",
+        version="abc",
+        image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
+        env={},
+    )
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    assert len(wf_spec.template.nodes) == 1
+    assert wf_spec.template.nodes[0].task_node.overrides is not None
+    assert wf_spec.template.nodes[0].task_node.overrides.resources.requests == [
+        _resources_models.ResourceEntry(_resources_models.ResourceName.CPU, "1"),
+        _resources_models.ResourceEntry(_resources_models.ResourceName.MEMORY, "100"),
+        _resources_models.ResourceEntry(_resources_models.ResourceName.EPHEMERAL_STORAGE, "500Mi"),
+    ]
+    assert wf_spec.template.nodes[0].task_node.overrides.resources.limits == []
+
+
+def test_resource_limits_override():
+    @task
+    def t1(a: str) -> str:
+        return f"*~*~*~{a}*~*~*~"
+
+    @workflow
+    def my_wf(a: typing.List[str]) -> typing.List[str]:
+        mappy = map_task(t1)
+        map_node = mappy(a=a).with_overrides(
+            limits=(Resources(cpu="2", mem="200", ephemeral_storage="1Gi")),
         )
-        return map_node.o0
+        return map_node
+
+    serialization_settings = context_manager.SerializationSettings(
+        project="test_proj",
+        domain="test_domain",
+        version="abc",
+        image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
+        env={},
+    )
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    assert len(wf_spec.template.nodes) == 1
+    assert wf_spec.template.nodes[0].task_node.overrides.resources.requests == []
+    assert wf_spec.template.nodes[0].task_node.overrides.resources.limits == [
+        _resources_models.ResourceEntry(_resources_models.ResourceName.CPU, "2"),
+        _resources_models.ResourceEntry(_resources_models.ResourceName.MEMORY, "200"),
+        _resources_models.ResourceEntry(_resources_models.ResourceName.EPHEMERAL_STORAGE, "1Gi"),
+    ]
+
+
+def test_resources_override():
+    @task
+    def t1(a: str) -> str:
+        return f"*~*~*~{a}*~*~*~"
+
+    @workflow
+    def my_wf(a: typing.List[str]) -> typing.List[str]:
+        mappy = map_task(t1)
+        map_node = mappy(a=a).with_overrides(
+            requests=Resources(cpu="1", mem="100", ephemeral_storage="500Mi"),
+            limits=(Resources(cpu="2", mem="200", ephemeral_storage="1Gi")),
+        )
+        return map_node
 
     serialization_settings = context_manager.SerializationSettings(
         project="test_proj",


### PR DESCRIPTION
Allows specifying requests or limits alone without the other. The current implementation requires that both be specified together.